### PR TITLE
Updated Package Publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -49,4 +49,4 @@ jobs:
       env:
         ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
       run: |
-        anaconda --verbose --token $ANACONDA_TOKEN upload --user joshburt build/noarch/mlflow-adsp-*.tar.bz2 --force
+        anaconda --verbose --token $ANACONDA_TOKEN upload --user ae5-admin build/noarch/mlflow-adsp-*.tar.bz2 --force

--- a/anaconda-project.yml
+++ b/anaconda-project.yml
@@ -45,7 +45,6 @@ commands:
 channels:
   - defaults
   - https://conda.anaconda.org/conda-forge
-  - https://conda.anaconda.org/joshburt
   - https://conda.anaconda.org/ae5-admin
 
 platforms:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - requests
 
 about:
-  home: https://github.com/shapeandshare/mlflow-adsp
+  home: https://github.com/Anaconda-Platform/mlflow-adsp
   summary: "MLFlow Plugin For The Anaconda Data Science Platform"
   license: Apache-2.0
   license_file: LICENSE

--- a/container/conda.yml
+++ b/container/conda.yml
@@ -1,14 +1,13 @@
 channels:
   - defaults
   - https://conda.anaconda.org/conda-forge
-  - https://conda.anaconda.org/joshburt
   - https://conda.anaconda.org/ae5-admin
 
 dependencies:
   - defaults:python=3.11
   - defaults:mlflow=2.6.0
   - ae5-admin:ae5-tools<1.0
-  - joshburt:mlflow-adsp<1.0
+  - ae5-admin:mlflow-adsp>=0.5,<1.0
   - defaults:tqdm
   - defaults:psutil
   - defaults:pydantic<2.0

--- a/docs/build/html/_sources/installation_guide.md.txt
+++ b/docs/build/html/_sources/installation_guide.md.txt
@@ -25,7 +25,7 @@ See `Variables` below for specific details on each.
 ### 2. Install Plugin
 
 ```shell
-conda install -c https://conda.anaconda.org/joshburt mlflow-adsp 
+conda install -c https://conda.anaconda.org/ae5-admin mlflow-adsp
 ```
 
 ## Variables

--- a/docs/source/installation_guide.md
+++ b/docs/source/installation_guide.md
@@ -25,7 +25,7 @@ See `Variables` below for specific details on each.
 ### 2. Install Plugin
 
 ```shell
-conda install -c https://conda.anaconda.org/joshburt mlflow-adsp 
+conda install -c https://conda.anaconda.org/ae5-admin mlflow-adsp 
 ```
 
 ## Variables


### PR DESCRIPTION
Moving plugin from personal repo, and channel to Anaconda for general availability.

Original Location: https://github.com/shapeandshare/mlflow-adsp
Original Publishing Channel: https://anaconda.org/joshburt/mlflow-adsp

This repository will need `ANACONDA_TOKEN` secret defined on it for publishing to succeed. - @A-Aron-T 