### PR TITLE
Remove timeout for loopback health call

### DIFF
--- a/mlflow_adsp/services/endpoint_manager.py
+++ b/mlflow_adsp/services/endpoint_manager.py
@@ -103,7 +103,7 @@ class EndpointManager:
 
         try:
             version_endpoint_url: str = f"http://{self.params.host}:{self.params.port}/version"
-            response: Response = requests.get(url=version_endpoint_url, timeout=1)
+            response: Response = requests.get(url=version_endpoint_url)
             if response.status_code != 200:
                 logger.debug("Service not yet healthy, waiting ..")
                 EndpointManager._proc_comm(process=process, timeout=self.params.timeout)

--- a/test/unit/services/test_endpoint_manager.py
+++ b/test/unit/services/test_endpoint_manager.py
@@ -386,7 +386,7 @@ def test_poll_network_service_gracefully_fails(monkeypatch):
     client: MagicMock = MagicMock()
     monkeypatch.setattr(subprocess, "Popen", MockPOpen)
 
-    def mock_get(url, timeout):
+    def mock_get(url):
         raise requests.exceptions.ConnectionError("Boom!")
 
     monkeypatch.setattr(requests, "get", mock_get)


### PR DESCRIPTION
These might be lengthly depending on model loads, removing requirement.